### PR TITLE
Automatic Error Recovery

### DIFF
--- a/iam_robolib/include/iam_robolib/robot_state_data.h
+++ b/iam_robolib/include/iam_robolib/robot_state_data.h
@@ -104,6 +104,8 @@ class RobotStateData {
   void log_gripper_state(franka::GripperState gripper_state);
   void log_skill_info(std::string info);
 
+  void clearAllBuffers();
+
  private:
   FileStreamLogger *file_logger_ = nullptr;
 

--- a/iam_robolib/include/iam_robolib/robots/franka_robot.h
+++ b/iam_robolib/include/iam_robolib/robots/franka_robot.h
@@ -34,6 +34,10 @@ class FrankaRobot : public Robot
 
   franka::Robot robot_;
   franka::Gripper gripper_;
+
+  void automaticErrorRecovery() {
+    robot_.automaticErrorRecovery();
+  }
 };
 
 #endif  // IAM_ROBOLIB_ROBOTS_FRANKA_ROBOT_H_

--- a/iam_robolib/include/iam_robolib/robots/robot.h
+++ b/iam_robolib/include/iam_robolib/robots/robot.h
@@ -16,6 +16,8 @@ class Robot
 
   virtual ~Robot() = default;
 
+  virtual void automaticErrorRecovery() = 0;
+
   std::string robot_ip_;
   RobotType robot_type_;
 

--- a/iam_robolib/include/iam_robolib/robots/ur5e_robot.h
+++ b/iam_robolib/include/iam_robolib/robots/ur5e_robot.h
@@ -82,6 +82,11 @@ class UR5eRobot : public Robot
 
   std::unique_ptr<URCommander> rt_commander_;
 
+  void automaticErrorRecovery() {
+    // TODO(jacky) this hasn't been implemented on UR5e
+    throw "Automatic Error Recovery hasn't been implemented on UR5e!";
+  }
+
  private:
   const int UR_RT_TRANSMIT_PORT_ = 30003;
   const int UR_RT_RECEIVE_PORT_ = 30013;

--- a/iam_robolib/include/iam_robolib/run_loop_shared_memory_handler.h
+++ b/iam_robolib/include/iam_robolib/run_loop_shared_memory_handler.h
@@ -50,6 +50,8 @@ class RunLoopSharedMemoryHandler {
 
   SharedBuffer getCurrentRobotStateBuffer();
 
+  void clearAllBuffers();
+
  private:
   SharedMemoryInfo shared_memory_info_=SharedMemoryInfo();
 

--- a/iam_robolib/include/iam_robolib/skill_info_manager.h
+++ b/iam_robolib/include/iam_robolib/skill_info_manager.h
@@ -25,6 +25,8 @@ class SkillInfoManager {
 
   void add_meta_skill(BaseMetaSkill* skill);
 
+  void clear_skill_and_meta_skill_list();
+
   BaseMetaSkill* get_meta_skill_with_id(int meta_skill_id);
 
  private:

--- a/iam_robolib/src/robot_state_data.cpp
+++ b/iam_robolib/src/robot_state_data.cpp
@@ -131,6 +131,31 @@ void RobotStateData::writeBufferData_1() {
     // std::cout << "Did save buffer 1\n";
 };
 
+void RobotStateData::clearAllBuffers() {
+  std::lock_guard<std::mutex> lock_0(buffer_0_mutex_);
+  std::lock_guard<std::mutex> lock_1(buffer_1_mutex_);
+  
+  log_skill_info_0_.clear();
+  log_pose_desired_0_.clear();
+  log_robot_state_0_.clear();
+  log_tau_j_0_.clear();
+  log_d_tau_j_0_.clear();
+  log_q_0_.clear();
+  log_q_d_0_.clear();
+  log_dq_0_.clear();
+  log_control_time_0_.clear();
+
+  log_skill_info_1_.clear();
+  log_pose_desired_1_.clear();
+  log_robot_state_1_.clear();
+  log_tau_j_1_.clear();
+  log_d_tau_j_1_.clear();
+  log_q_1_.clear();
+  log_q_d_1_.clear();
+  log_dq_1_.clear();
+  log_control_time_1_.clear();
+}
+
 void RobotStateData::startFileLoggerThread() {
     file_logger_thread_ = std::thread([&]() {
       // Sleep to achieve the desired print rate.

--- a/iam_robolib/src/run_loop.cpp
+++ b/iam_robolib/src/run_loop.cpp
@@ -501,7 +501,7 @@ void run_loop::setup_current_robot_state_io_thread() {
 }
 
 void run_loop::setup_watchdog_thread() {
-  int io_rate = 100;
+  int io_rate = 50;
   watchdog_thread_ = std::thread([&, io_rate]() {
       while (true) {
         std::this_thread::sleep_for(
@@ -649,9 +649,6 @@ void run_loop::run_on_franka() {
       std::cerr << error_description << std::endl;
       robot_state_data_->writeCurrentBufferData();
       robot_state_data_->printGlobalData(50);
-      logger_.print_error_log();
-      logger_.print_warning_log();
-      logger_.print_info_log();
 
       // Clear buffers and reset stateful variables about skills
       RunLoopProcessInfo* run_loop_info = shared_memory_handler_->getRunLoopProcessInfo();

--- a/iam_robolib/src/run_loop.cpp
+++ b/iam_robolib/src/run_loop.cpp
@@ -165,6 +165,7 @@ void run_loop::update_process_info() {
                 boost::interprocess::defer_lock);
     try {
       if (lock.try_lock()) {
+        run_loop_info->reset_watchdog_counter();
         run_loop_info->set_is_running_skill(is_executing_skill);
 
         // We have a skill that we have finished. Make sure we update this in RunLoopProcessInfo.
@@ -339,8 +340,6 @@ void run_loop::setup_save_robot_state_thread() {
 void run_loop::setup_current_robot_state_io_thread() {
   int io_rate = 100;
   current_robot_state_io_thread_ = std::thread([&, io_rate]() {
-      std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
-
       while (running_skills_) {
         std::this_thread::sleep_for(
             std::chrono::milliseconds(static_cast<int>((1.0 / io_rate * 1000.0))));
@@ -501,22 +500,41 @@ void run_loop::setup_current_robot_state_io_thread() {
   });
 }
 
+void run_loop::setup_watchdog_thread() {
+  int io_rate = 100;
+  watchdog_thread_ = std::thread([&, io_rate]() {
+      while (true) {
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(static_cast<int>((1.0 / io_rate * 1000.0))));
+          RunLoopProcessInfo* run_loop_info = shared_memory_handler_->getRunLoopProcessInfo();
+          boost::interprocess::scoped_lock<
+                  boost::interprocess::interprocess_mutex> lock(
+                      *(shared_memory_handler_->getRunLoopProcessInfoMutex()),
+                      boost::interprocess::defer_lock);
+          if (lock.try_lock()) {
+            run_loop_info->reset_watchdog_counter();
+          } 
+      }
+  });
+}
+
 void run_loop::setup_robot_default_behavior() {
   switch(robot_->robot_type_)
   {
     case RobotType::FRANKA: {
         // Set additional parameters always before the control loop, NEVER in the control loop!
         // Set collision behavior.
-        /*robot_->robot_.setCollisionBehavior(
-            {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
-            {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
-            {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}},
-            {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}});*/
         dynamic_cast<FrankaRobot* >(robot_)->robot_.setCollisionBehavior(
             {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{120.0, 120.0, 118.0, 118.0, 116.0, 114.0, 112.0}},
             {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{120.0, 120.0, 118.0, 118.0, 116.0, 114.0, 112.0}},
             {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{120.0, 120.0, 120.0, 125.0, 125.0, 125.0}},
             {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{120.0, 120.0, 120.0, 125.0, 125.0, 125.0}});
+        // TODO(jacky): Use these parameters to make robot super sensitive to collisions. Useful for testing collision error handling.
+        // dynamic_cast<FrankaRobot* >(robot_)->robot_.setCollisionBehavior(
+        //     {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
+        //     {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}}, {{20.0, 20.0, 18.0, 18.0, 16.0, 14.0, 12.0}},
+        //     {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}},
+        //     {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}}, {{20.0, 20.0, 20.0, 25.0, 25.0, 25.0}});
 
         dynamic_cast<FrankaRobot* >(robot_)->robot_.setJointImpedance({{3000, 3000, 3000, 2500, 2500, 2000, 2000}});
         dynamic_cast<FrankaRobot* >(robot_)->robot_.setCartesianImpedance({{3000, 3000, 3000, 300, 300, 300}});
@@ -548,6 +566,15 @@ void run_loop::log_skill_info(BaseSkill* skill) {
   std::cout << log_desc << "\n" << std::endl;
 };
 
+void run_loop::set_robolib_status(bool is_ready, std::string error_message) {
+  RunLoopProcessInfo* run_loop_info = shared_memory_handler_->getRunLoopProcessInfo();
+    boost::interprocess::scoped_lock<
+            boost::interprocess::interprocess_mutex> lock(
+                *(shared_memory_handler_->getRunLoopProcessInfoMutex()));
+  run_loop_info->set_is_ready(is_ready);
+  run_loop_info->set_error_description(error_message);
+}
+
 void run_loop::run_on_franka() {
   // Wait for sometime to let the client add data to the buffer
   std::this_thread::sleep_for(std::chrono::seconds(2));
@@ -556,61 +583,93 @@ void run_loop::run_on_franka() {
   auto milli = std::chrono::milliseconds(1);
 
   setup_robot_default_behavior();
+  setup_watchdog_thread();
+  setup_data_loggers();
+  setup_current_robot_state_io_thread();
+  
+  // TODO(Mohit): This causes a weird race condition between reading the robot state and 
+  // running the control loop. It prevents iam_robolib from running when robot is in guide mode.
+  // setup_save_robot_state_thread();
 
-  try {
-    running_skills_ = true;
-    setup_data_loggers();
-    setup_current_robot_state_io_thread();
-    // TODO(Mohit): This causes a weird race condition between reading the robot state and 
-    // running the control loop. It prevents iam_robolib from running when robot is in guide mode.
-    // setup_save_robot_state_thread();
+  while (true) {
+    try {
+      running_skills_ = true;
+      set_robolib_status(true, "");
 
-    while (1) {
-      start = std::chrono::high_resolution_clock::now();
+      while (true) {
+        start = std::chrono::high_resolution_clock::now();
 
-      // Execute the current skill (traj_generator, FBC are here)
-      BaseSkill* skill = skill_manager_.get_current_skill();
-      BaseMetaSkill *meta_skill = skill_manager_.get_current_meta_skill();
+        // Execute the current skill (traj_generator, FBC are here)
+        BaseSkill* skill = skill_manager_.get_current_skill();
+        BaseMetaSkill *meta_skill = skill_manager_.get_current_meta_skill();
 
-      // NOTE: We keep on running the last skill even if it is finished!!
-      if (skill != nullptr && meta_skill != nullptr) {
-        if (!meta_skill->isComposableSkill() && !skill->get_termination_handler()->done_) {
-          // Execute skill.
-          log_skill_info(skill);
-          meta_skill->execute_skill_on_franka(this, dynamic_cast<FrankaRobot* >(robot_), robot_state_data_);
-        } else if (meta_skill->isComposableSkill()) {
-          log_skill_info(skill);
-          meta_skill->execute_skill_on_franka(this, dynamic_cast<FrankaRobot* >(robot_), robot_state_data_);
-        } else {
-          finish_current_skill(skill);
-          std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        // NOTE: We keep on running the last skill even if it is finished!!
+        if (skill != nullptr && meta_skill != nullptr) {
+          if (!meta_skill->isComposableSkill() && !skill->get_termination_handler()->done_) {
+            // Execute skill.
+            log_skill_info(skill);
+            meta_skill->execute_skill_on_franka(this, dynamic_cast<FrankaRobot* >(robot_), robot_state_data_);
+          } else if (meta_skill->isComposableSkill()) {
+            log_skill_info(skill);
+            meta_skill->execute_skill_on_franka(this, dynamic_cast<FrankaRobot* >(robot_), robot_state_data_);
+          } else {
+            finish_current_skill(skill);
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+          }
         }
+
+        // Complete old skills and acquire new skills
+        update_process_info();
+
+        // Start new skill, if possible
+        BaseSkill* new_skill = skill_manager_.get_current_skill();
+        if (should_start_new_skill(skill, new_skill)) {
+          std::cout << "Will start skill\n";
+          start_new_skill(new_skill);
+        }
+
+        // Sleep to maintain 1Khz frequency, not sure if this is required or not.
+        auto finish = std::chrono::high_resolution_clock::now();
+        // Wait for start + milli - finish
+        auto elapsed = start + milli - finish;
+        // TODO(Mohit): We need to sleep for now because the ROS client side sends messasges sequentially
+        // and hence we have skills being repeated because the new skill arrives with a delay.
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
+    } catch (const franka::Exception& ex) {
+      std::cout << "Caught Franka Exception\n";
+      running_skills_ = false;
 
-      // Complete old skills and acquire new skills
-      update_process_info();
+      // // Alert franka_action_lib that an exception has occurred      
+      std::string error_description = ex.what();
+      set_robolib_status(false, error_description);
 
-      // Start new skill, if possible
-      BaseSkill* new_skill = skill_manager_.get_current_skill();
-      if (should_start_new_skill(skill, new_skill)) {
-        std::cout << "Will start skill\n";
-        start_new_skill(new_skill);
-      }
+      // Log data
+      std::cout << "Franka exception occurred during control loop. Will reset." << std::endl;
+      std::cerr << error_description << std::endl;
+      robot_state_data_->writeCurrentBufferData();
+      robot_state_data_->printGlobalData(50);
+      logger_.print_error_log();
+      logger_.print_warning_log();
+      logger_.print_info_log();
 
-      // Sleep to maintain 1Khz frequency, not sure if this is required or not.
-      auto finish = std::chrono::high_resolution_clock::now();
-      // Wait for start + milli - finish
-      auto elapsed = start + milli - finish;
-      // TODO(Mohit): We need to sleep for now because the ROS client side sends messasges sequentially
-      // and hence we have skills being repeated because the new skill arrives with a delay.
-      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      // Clear buffers and reset stateful variables about skills
+      RunLoopProcessInfo* run_loop_info = shared_memory_handler_->getRunLoopProcessInfo();
+      boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> run_loop_info_lock(
+          *(shared_memory_handler_->getRunLoopProcessInfoMutex())
+        );
+      run_loop_info->reset_skill_vars();
+
+      skill_manager_.clear_skill_and_meta_skill_list();
+      shared_memory_handler_->clearAllBuffers();
+      robot_state_data_->clearAllBuffers();
+
+      // Perform error recovery
+      robot_->automaticErrorRecovery();
+
+      std::cout << "Error recovery finished\n";
+      continue;
     }
-  } catch (const franka::Exception& ex) {
-    std::cout << "Franka exception occurred during control loop. Will exit." << std::endl;
-    std::cerr << ex.what() << std::endl;
-    logger_.print_error_log();
-    logger_.print_warning_log();
-    logger_.print_info_log();
   }
 
   if (print_thread_.joinable()) {

--- a/iam_robolib/src/run_loop_shared_memory_handler.cpp
+++ b/iam_robolib/src/run_loop_shared_memory_handler.cpp
@@ -77,6 +77,44 @@ SharedBuffer RunLoopSharedMemoryHandler::getCurrentRobotStateBuffer() {
     return current_robot_state_buffer_;
 }
 
+void RunLoopSharedMemoryHandler::clearAllBuffers() {
+    boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> shared_memory_0_lock(*shared_memory_mutex_0_);
+    boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> shared_memory_1_lock(*shared_memory_mutex_1_);
+    boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> shared_sensor_data_0_lock(*shared_sensor_data_mutex_0_);
+    boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> shared_sensor_data_1_lock(*shared_sensor_data_mutex_1_);
+    boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> shared_execution_result_0_lock(*shared_execution_result_mutex_0_);
+    boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> shared_execution_result_1_lock(*shared_execution_result_mutex_1_);
+    boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> shared_current_robot_state_lock(*shared_current_robot_state_mutex_);
+
+    memset(traj_gen_buffer_0_, 0.f, shared_memory_info_.getSizeForTrajectoryParameters() * sizeof(float));
+    memset(feedback_controller_buffer_0_, 0.f, shared_memory_info_.getSizeForFeedbackControllerParameters() * sizeof(float));
+    memset(termination_buffer_0_, 0.f, shared_memory_info_.getSizeForTerminationParameters() * sizeof(float));
+    memset(timer_buffer_0_, 0.f, shared_memory_info_.getSizeForTimerParameters() * sizeof(float));
+
+    memset(traj_gen_buffer_1_, 0.f, shared_memory_info_.getSizeForTrajectoryParameters() * sizeof(float));
+    memset(feedback_controller_buffer_1_, 0.f, shared_memory_info_.getSizeForFeedbackControllerParameters() * sizeof(float));
+    memset(termination_buffer_1_, 0.f, shared_memory_info_.getSizeForTerminationParameters() * sizeof(float));
+    memset(timer_buffer_1_, 0.f, shared_memory_info_.getSizeForTimerParameters() * sizeof(float));
+
+    memset(traj_gen_sensor_buffer_0_, 0.f, shared_memory_info_.getSizeForTrajectorySensorData() * sizeof(float));
+    memset(feedback_controller_sensor_buffer_0_, 0.f, shared_memory_info_.getSizeForFeedbackControllerSensorData() * sizeof(float));
+    memset(termination_sensor_buffer_0_, 0.f, shared_memory_info_.getSizeForTerminationSensorData() * sizeof(float));
+    memset(timer_sensor_buffer_0_, 0.f, shared_memory_info_.getSizeForTimerSensorData() * sizeof(float));
+
+    memset(traj_gen_sensor_buffer_1_, 0.f, shared_memory_info_.getSizeForTrajectorySensorData() * sizeof(float));
+    memset(feedback_controller_sensor_buffer_1_, 0.f, shared_memory_info_.getSizeForFeedbackControllerSensorData() * sizeof(float));
+    memset(termination_sensor_buffer_1_, 0.f, shared_memory_info_.getSizeForTerminationSensorData() * sizeof(float));
+    memset(timer_sensor_buffer_1_, 0.f, shared_memory_info_.getSizeForTimerSensorData() * sizeof(float));
+
+    memset(execution_result_buffer_0_, 0.f, shared_memory_info_.getSizeForExecutionResultData() * sizeof(float));
+    memset(execution_feedback_buffer_0_, 0.f, shared_memory_info_.getSizeForExecutionFeedbackData() * sizeof(float));
+
+    memset(execution_result_buffer_1_, 0.f, shared_memory_info_.getSizeForExecutionResultData() * sizeof(float));
+    memset(execution_feedback_buffer_1_, 0.f, shared_memory_info_.getSizeForExecutionFeedbackData() * sizeof(float));
+
+    memset(current_robot_state_buffer_, 0.f, shared_memory_info_.getSizeForCurrentRobotState() * sizeof(float));
+}
+
 void RunLoopSharedMemoryHandler::start() {
   // Start processing, might want to do some pre-processing
   std::cout << "start run loop.\n";
@@ -329,8 +367,8 @@ void RunLoopSharedMemoryHandler::start() {
   region_execution_result_buffer_0_ = boost::interprocess::mapped_region(
       shared_execution_result_0_,
       boost::interprocess::read_write,
-      shared_memory_info_.getOffsetForExecutionReturnData(),
-      shared_memory_info_.getSizeForExecutionReturnData()
+      shared_memory_info_.getOffsetForExecutionResultData(),
+      shared_memory_info_.getSizeForExecutionResultData()
   );
   execution_result_buffer_0_ = reinterpret_cast<SharedBuffer>(region_execution_result_buffer_0_.get_address());
 
@@ -355,8 +393,8 @@ void RunLoopSharedMemoryHandler::start() {
   region_execution_result_buffer_1_ = boost::interprocess::mapped_region(
       shared_execution_result_1_,
       boost::interprocess::read_write,
-      shared_memory_info_.getOffsetForExecutionReturnData(),
-      shared_memory_info_.getSizeForExecutionReturnData()
+      shared_memory_info_.getOffsetForExecutionResultData(),
+      shared_memory_info_.getSizeForExecutionResultData()
   );
   execution_result_buffer_1_ = reinterpret_cast<SharedBuffer>(region_execution_result_buffer_1_.get_address());
 

--- a/iam_robolib/src/skill_info_manager.cpp
+++ b/iam_robolib/src/skill_info_manager.cpp
@@ -58,3 +58,8 @@ BaseMetaSkill* SkillInfoManager::get_meta_skill_with_id(int meta_skill_id) {
   }
   return nullptr;
 }
+
+void SkillInfoManager::clear_skill_and_meta_skill_list() {
+  skill_list_.clear();
+  meta_skill_list_.clear();
+}

--- a/iam_robolib/src/skills/force_torque_skill.cpp
+++ b/iam_robolib/src/skills/force_torque_skill.cpp
@@ -24,74 +24,61 @@ void ForceTorqueSkill::execute_skill() {
 
 void ForceTorqueSkill::execute_skill_on_franka(FrankaRobot* robot,
                                                RobotStateData *robot_state_data) {
+  double time = 0.0;
+  int log_counter = 0;
 
-  try {
-    double time = 0.0;
-    int log_counter = 0;
+  std::cout << "Will run the control loop\n";
 
-    std::cout << "Will run the control loop\n";
+  franka::Model model = robot->getModel();
 
-    franka::Model model = robot->getModel();
+  // get torque offset from gravity
+  franka::RobotState initial_state = robot->getRobotState();
+  Eigen::VectorXd initial_tau_ext(7);
+  std::array<double, 7> gravity_array = model.gravity(initial_state);
+  Eigen::Map<Eigen::Matrix<double, 7, 1> > initial_tau_measured(initial_state.tau_J.data());
+  Eigen::Map<Eigen::Matrix<double, 7, 1> > initial_gravity(gravity_array.data());
+  initial_tau_ext = initial_tau_measured - initial_gravity;
 
-    // get torque offset from gravity
-    franka::RobotState initial_state = robot->getRobotState();
-    Eigen::VectorXd initial_tau_ext(7);
-    std::array<double, 7> gravity_array = model.gravity(initial_state);
-    Eigen::Map<Eigen::Matrix<double, 7, 1> > initial_tau_measured(initial_state.tau_J.data());
-    Eigen::Map<Eigen::Matrix<double, 7, 1> > initial_gravity(gravity_array.data());
-    initial_tau_ext = initial_tau_measured - initial_gravity;
+  auto force_control_callback = [&](const franka::RobotState& robot_state,
+                                    franka::Duration period) -> franka::Torques {  
+    if (time == 0.0) {
+      traj_generator_->initialize_trajectory(robot_state);
+    }
+    time += period.toSec();
+    traj_generator_->time_ = time;
+    traj_generator_->dt_ = period.toSec();
+    traj_generator_->get_next_step();
 
-    auto force_control_callback = [&](const franka::RobotState& robot_state,
-                                      franka::Duration period) -> franka::Torques {
-      if (time == 0.0) {
-        traj_generator_->initialize_trajectory(robot_state);
-      }
-      time += period.toSec();
-      traj_generator_->time_ = time;
-      traj_generator_->dt_ = period.toSec();
-      traj_generator_->get_next_step();
+    bool done = termination_handler_->should_terminate(traj_generator_);
+    double* force_torque_desired_ptr = &(traj_generator_->force_torque_desired_[0]);
+    Eigen::Map<Eigen::VectorXd> desired_force_torque(force_torque_desired_ptr, 6);
 
-      bool done = termination_handler_->should_terminate(traj_generator_);
-      double* force_torque_desired_ptr = &(traj_generator_->force_torque_desired_[0]);
-      Eigen::Map<Eigen::VectorXd> desired_force_torque(force_torque_desired_ptr, 6);
+    log_counter += 1;
+    if (log_counter % 1 == 0) {
+      robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
+      robot_state_data->log_robot_state(robot_state, time);
+    }
 
-      log_counter += 1;
-      if (log_counter % 1 == 0) {
-        robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
-        robot_state_data->log_robot_state(robot_state, time);
-      }
+    // get jacobian
+    std::array<double, 42> jacobian_array =
+        model.zeroJacobian(franka::Frame::kEndEffector, robot_state);
+    Eigen::Map<const Eigen::Matrix<double, 6, 7> > jacobian(jacobian_array.data());
 
-      // get jacobian
-      std::array<double, 42> jacobian_array =
-          model.zeroJacobian(franka::Frame::kEndEffector, robot_state);
-      Eigen::Map<const Eigen::Matrix<double, 6, 7> > jacobian(jacobian_array.data());
+    // compute control torques
+    Eigen::VectorXd tau_d(7);
+    tau_d << jacobian.transpose() * desired_force_torque;
 
-      // compute control torques
-      Eigen::VectorXd tau_d(7);
-      tau_d << jacobian.transpose() * desired_force_torque;
+    std::array<double, 7> tau_d_array{};
+    Eigen::VectorXd::Map(&tau_d_array[0], 7) = tau_d;
 
-      std::array<double, 7> tau_d_array{};
-      Eigen::VectorXd::Map(&tau_d_array[0], 7) = tau_d;
+    if (done) {
+      franka::Torques torques(tau_d_array);
+      return franka::MotionFinished(torques);
+    }
 
-      if (done) {
-        franka::Torques torques(tau_d_array);
-        return franka::MotionFinished(torques);
-      }
+    return tau_d_array;
+  };
 
-      return tau_d_array;
-    };
-
-    robot->robot_.control(force_control_callback);
-
-  } catch (const franka::Exception& ex) {
-    run_loop::running_skills_ = false;
-    std::cerr << ex.what() << std::endl;
-    // Make sure we don't lose data.
-    robot_state_data->writeCurrentBufferData();
-
-    // print last 50 values
-    robot_state_data->printGlobalData(50);
-    robot_state_data->file_logger_thread_.join();
-  }
+  robot->robot_.control(force_control_callback);
 }
 

--- a/iam_robolib/src/skills/joint_pose_continuous_skill.cpp
+++ b/iam_robolib/src/skills/joint_pose_continuous_skill.cpp
@@ -27,100 +27,89 @@ bool JointPoseContinuousSkill::isComposableSkill() {
 
 void JointPoseContinuousSkill::execute_skill_on_franka(run_loop *run_loop, FrankaRobot* robot,
                                                        RobotStateData *robot_state_data) {
-  try {
-    double time = 0.0;
-    double current_skill_time = 0.0;
-    int log_counter = 0;
 
-    SkillInfoManager *skill_info_manager = run_loop->getSkillInfoManager();
-    BaseSkill *current_skill = skill_info_manager->get_current_skill();
+  double time = 0.0;
+  double current_skill_time = 0.0;
+  int log_counter = 0;
 
-    std::cout << "Will run JointPoseContinuousSkill control loop\n";
+  SkillInfoManager *skill_info_manager = run_loop->getSkillInfoManager();
+  BaseSkill *current_skill = skill_info_manager->get_current_skill();
 
-    franka::Model model = robot->getModel();
-    franka::RobotState initial_robot_state = robot->getRobotState();
-    std::array<double, 7> last_dmp_q = initial_robot_state.q;
-    std::array<double, 7> last_dmp_dq = initial_robot_state.dq;
+  std::cout << "Will run JointPoseContinuousSkill control loop\n";
 
-    std::function<franka::JointPositions(const franka::RobotState&, franka::Duration)>
-        joint_pose_callback = [&](
-        const franka::RobotState& robot_state,
-        franka::Duration period) -> franka::JointPositions {
+  franka::Model model = robot->getModel();
+  franka::RobotState initial_robot_state = robot->getRobotState();
+  std::array<double, 7> last_dmp_q = initial_robot_state.q;
+  std::array<double, 7> last_dmp_dq = initial_robot_state.dq;
 
-      DmpTrajectoryGenerator* traj_generator = static_cast<DmpTrajectoryGenerator *>(
-          current_skill->get_trajectory_generator());
-      if (current_skill_time == 0.0) {
-        traj_generator->initialize_trajectory(robot_state);
-        traj_generator->y_ = last_dmp_q;
-        traj_generator->dy_ = last_dmp_dq;
-      }
+  std::function<franka::JointPositions(const franka::RobotState&, franka::Duration)>
+      joint_pose_callback = [&](
+      const franka::RobotState& robot_state,
+      franka::Duration period) -> franka::JointPositions {
 
-      double period_in_seconds = period.toSec();
-      time += period_in_seconds;
-      current_skill_time += period_in_seconds;
-      traj_generator->time_ = current_skill_time;
-      traj_generator->dt_ = static_cast<float>(period_in_seconds);
-      traj_generator->get_next_step();
+    DmpTrajectoryGenerator* traj_generator = static_cast<DmpTrajectoryGenerator *>(
+        current_skill->get_trajectory_generator());
+    if (current_skill_time == 0.0) {
+      traj_generator->initialize_trajectory(robot_state);
+      traj_generator->y_ = last_dmp_q;
+      traj_generator->dy_ = last_dmp_dq;
+    }
 
-      log_counter += 1;
-      if (log_counter % 1 == 0) {
-        robot_state_data->log_pose_desired(traj_generator->pose_desired_);
-        robot_state_data->log_robot_state(robot_state, time);
-      }
+    double period_in_seconds = period.toSec();
+    time += period_in_seconds;
+    current_skill_time += period_in_seconds;
+    traj_generator->time_ = current_skill_time;
+    traj_generator->dt_ = static_cast<float>(period_in_seconds);
+    traj_generator->get_next_step();
 
-      TerminationHandler *termination_handler = current_skill->get_termination_handler();
-      bool done = termination_handler->should_terminate(traj_generator);
-      franka::JointPositions joint_desired(traj_generator->joint_desired_);
+    log_counter += 1;
+    if (log_counter % 1 == 0) {
+      robot_state_data->log_pose_desired(traj_generator->pose_desired_);
+      robot_state_data->log_robot_state(robot_state, time);
+    }
 
-      if(done) {
-        // Finish current skill and update RunLoopProcessInfo.
-        run_loop->didFinishSkillInMetaSkill(current_skill);
-        // Get new skill, the above update might have found a new skill.
-        BaseSkill *new_skill = skill_info_manager->get_current_skill();
+    TerminationHandler *termination_handler = current_skill->get_termination_handler();
+    bool done = termination_handler->should_terminate(traj_generator);
+    franka::JointPositions joint_desired(traj_generator->joint_desired_);
 
-        if (new_skill->get_skill_id() == current_skill->get_skill_id()) {
-          // No new skill, let's just continue with the current skill.
-          // current_skill_time = 0.0;
+    if(done) {
+      // Finish current skill and update RunLoopProcessInfo.
+      run_loop->didFinishSkillInMetaSkill(current_skill);
+      // Get new skill, the above update might have found a new skill.
+      BaseSkill *new_skill = skill_info_manager->get_current_skill();
+
+      if (new_skill->get_skill_id() == current_skill->get_skill_id()) {
+        // No new skill, let's just continue with the current skill.
+        // current_skill_time = 0.0;
+        last_dmp_q = traj_generator->y_;
+        last_dmp_dq = traj_generator->dy_;
+
+        std::cout << "Meta skill continuing with old skill: " << current_skill->get_skill_id() << "\n";
+      } else {
+        if (current_skill->get_meta_skill_id() != new_skill->get_meta_skill_id()) {
+          // New meta skill, so we should stop this.
+          skill_info_manager->get_current_meta_skill()->setMetaSkillStatus(SkillStatus::FINISHED);
+          last_dmp_q = traj_generator->y_;
+          last_dmp_dq = traj_generator->dy_;
+          std::cout << "Meta skill finished: " << skill_info_manager->get_current_meta_skill()->getMetaSkillId() << "\n";
+          return franka::MotionFinished(franka::JointPositions(robot_state.q_d));
+        } else {
+          // Same meta skill, let's continue
+          run_loop->start_new_skill(new_skill);
+          current_skill_time = 0.0;
+
           last_dmp_q = traj_generator->y_;
           last_dmp_dq = traj_generator->dy_;
 
-          std::cout << "Meta skill continuing with old skill: " << current_skill->get_skill_id() << "\n";
-        } else {
-          if (current_skill->get_meta_skill_id() != new_skill->get_meta_skill_id()) {
-            // New meta skill, so we should stop this.
-            skill_info_manager->get_current_meta_skill()->setMetaSkillStatus(SkillStatus::FINISHED);
-            last_dmp_q = traj_generator->y_;
-            last_dmp_dq = traj_generator->dy_;
-            std::cout << "Meta skill finished: " << skill_info_manager->get_current_meta_skill()->getMetaSkillId() << "\n";
-            return franka::MotionFinished(franka::JointPositions(robot_state.q_d));
-          } else {
-            // Same meta skill, let's continue
-            run_loop->start_new_skill(new_skill);
-            current_skill_time = 0.0;
-
-            last_dmp_q = traj_generator->y_;
-            last_dmp_dq = traj_generator->dy_;
-
-            current_skill = new_skill;
-            std::cout << "New skill: " << new_skill->get_skill_id() << ", found for meta skill: " <<
-              skill_info_manager->get_current_meta_skill()->getMetaSkillId() << "\n";
-          }
+          current_skill = new_skill;
+          std::cout << "New skill: " << new_skill->get_skill_id() << ", found for meta skill: " <<
+            skill_info_manager->get_current_meta_skill()->getMetaSkillId() << "\n";
         }
       }
-      return joint_desired;
-    };
+    }
+    return joint_desired;
+  };
 
-    robot->robot_.control(joint_pose_callback);
-
-  } catch (const franka::Exception& ex) {
-    run_loop::running_skills_ = false;
-    std::cerr << ex.what() << std::endl;
-    // Make sure we don't lose data.
-    robot_state_data->writeCurrentBufferData();
-
-    // print last 50 values
-    robot_state_data->printGlobalData(50);
-    robot_state_data->file_logger_thread_.join();
-  }
+  robot->robot_.control(joint_pose_callback);
 }
 

--- a/iam_robolib/src/skills/joint_pose_with_torque_control_skill.cpp
+++ b/iam_robolib/src/skills/joint_pose_with_torque_control_skill.cpp
@@ -22,61 +22,48 @@ void JointPoseWithTorqueControlSkill::execute_skill() {
 
 void JointPoseWithTorqueControlSkill::execute_skill_on_franka(FrankaRobot* robot,
                                                               RobotStateData *robot_state_data) {
+  double time = 0.0;
+  int log_counter = 0;
 
-  try {
-    double time = 0.0;
-    int log_counter = 0;
+  std::cout << "Will run the control loop\n";
 
-    std::cout << "Will run the control loop\n";
+  franka::Model model = robot->getModel();
 
-    franka::Model model = robot->getModel();
+  std::function<franka::JointPositions(const franka::RobotState&, franka::Duration)>
+      joint_pose_callback = [=, &time, &log_counter](
+      const franka::RobotState& robot_state,
+      franka::Duration period) -> franka::JointPositions {
+    if (time == 0.0) {
+      traj_generator_->initialize_trajectory(robot_state);
+    }
+    time += period.toSec();
+    traj_generator_->time_ = time;
+    traj_generator_->dt_ = period.toSec();
+    traj_generator_->get_next_step();
 
-    std::function<franka::JointPositions(const franka::RobotState&, franka::Duration)>
-        joint_pose_callback = [=, &time, &log_counter](
-        const franka::RobotState& robot_state,
-        franka::Duration period) -> franka::JointPositions {
-      if (time == 0.0) {
-        traj_generator_->initialize_trajectory(robot_state);
-      }
-      time += period.toSec();
-      traj_generator_->time_ = time;
-      traj_generator_->dt_ = period.toSec();
-      traj_generator_->get_next_step();
+    bool done = termination_handler_->should_terminate(traj_generator_);
+    franka::JointPositions joint_desired(traj_generator_->joint_desired_);
 
-      bool done = termination_handler_->should_terminate(traj_generator_);
-      franka::JointPositions joint_desired(traj_generator_->joint_desired_);
+    log_counter += 1;
+    if (log_counter % 1 == 0) {
+      robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
+      robot_state_data->log_robot_state(robot_state, time);
+    }
 
-      log_counter += 1;
-      if (log_counter % 1 == 0) {
-        robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
-        robot_state_data->log_robot_state(robot_state, time);
-      }
+    if(done or time >= traj_generator_->run_time_) {
+      return franka::MotionFinished(joint_desired);
+    }
+    return joint_desired;
+  };
 
-      if(done or time >= traj_generator_->run_time_) {
-        return franka::MotionFinished(joint_desired);
-      }
-      return joint_desired;
-    };
+  std::function<franka::Torques(const franka::RobotState&,
+      franka::Duration)> impedance_control_callback = [&](
+        const franka::RobotState& state, franka::Duration) -> franka::Torques {
+        feedback_controller_->get_next_step();
+        return feedback_controller_->tau_d_array_;
+      };
 
-    std::function<franka::Torques(const franka::RobotState&,
-        franka::Duration)> impedance_control_callback = [&](
-          const franka::RobotState& state, franka::Duration) -> franka::Torques {
-          feedback_controller_->get_next_step();
-          return feedback_controller_->tau_d_array_;
-        };
-
-    robot->robot_.control(impedance_control_callback, joint_pose_callback);
-
-  } catch (const franka::Exception& ex) {
-    run_loop::running_skills_ = false;
-    std::cerr << ex.what() << std::endl;
-    // Make sure we don't lose data.
-    robot_state_data->writeCurrentBufferData();
-
-    // print last 50 values
-    robot_state_data->printGlobalData(50);
-    robot_state_data->file_logger_thread_.join();
-  }
+  robot->robot_.control(impedance_control_callback, joint_pose_callback);
 }
 
 void JointPoseWithTorqueControlSkill::execute_meta_skill_on_franka(FrankaRobot *robot,

--- a/iam_robolib/src/skills/skill_info.cpp
+++ b/iam_robolib/src/skills/skill_info.cpp
@@ -30,67 +30,54 @@ void SkillInfo::execute_skill() {
 void SkillInfo::execute_skill_on_franka(FrankaRobot* robot,
                                         RobotStateData *robot_state_data) {
 
-  try {
-    double time = 0.0;
-    int log_counter = 0;
+  double time = 0.0;
+  int log_counter = 0;
 
-    std::cout << "Will run the control loop\n";
+  std::cout << "Will run the control loop\n";
 
-    franka::Model model = robot->getModel();
+  franka::Model model = robot->getModel();
 
-    // define callback for the torque control loop
-    std::function<franka::Torques(const franka::RobotState&, franka::Duration)>
-        impedance_control_callback = [&, &time](const franka::RobotState& robot_state,
-                                                franka::Duration period) -> franka::Torques {
+  // define callback for the torque control loop
+  std::function<franka::Torques(const franka::RobotState&, franka::Duration)>
+      impedance_control_callback = [&, &time](const franka::RobotState& robot_state,
+                                              franka::Duration period) -> franka::Torques {
 
-      if (time == 0.0) {
-        traj_generator_->initialize_trajectory(robot_state);
-        feedback_controller_->initialize_controller(&model);
-      }
+    if (time == 0.0) {
+      traj_generator_->initialize_trajectory(robot_state);
+      feedback_controller_->initialize_controller(&model);
+    }
 
-      if (robot_state_data->mutex_.try_lock()) {
-        robot_state_data->counter_ += 1;
-        robot_state_data->time_ =  period.toSec();
-        robot_state_data->has_data_ = true;
-        robot_state_data->mutex_.unlock();
-      }
+    if (robot_state_data->mutex_.try_lock()) {
+      robot_state_data->counter_ += 1;
+      robot_state_data->time_ =  period.toSec();
+      robot_state_data->has_data_ = true;
+      robot_state_data->mutex_.unlock();
+    }
 
-      traj_generator_->dt_ = period.toSec();
-      traj_generator_->time_ += period.toSec();
-      time += period.toSec();
-      log_counter += 1;
+    traj_generator_->dt_ = period.toSec();
+    traj_generator_->time_ += period.toSec();
+    time += period.toSec();
+    log_counter += 1;
 
-      traj_generator_->get_next_step();
+    traj_generator_->get_next_step();
 
-      if (log_counter % 1 == 0) {
-        robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
-        robot_state_data->log_robot_state(robot_state, time);
-      }
+    if (log_counter % 1 == 0) {
+      robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
+      robot_state_data->log_robot_state(robot_state, time);
+    }
 
-      feedback_controller_->get_next_step(robot_state, traj_generator_);
+    feedback_controller_->get_next_step(robot_state, traj_generator_);
 
-      bool done = termination_handler_->should_terminate_on_franka(robot_state, traj_generator_);
+    bool done = termination_handler_->should_terminate_on_franka(robot_state, traj_generator_);
 
-      if(done) {
-        return franka::MotionFinished(franka::Torques(feedback_controller_->tau_d_array_));
-      }
+    if(done) {
+      return franka::MotionFinished(franka::Torques(feedback_controller_->tau_d_array_));
+    }
 
+    return feedback_controller_->tau_d_array_;
+  };
 
-      return feedback_controller_->tau_d_array_;
-    };
-
-    robot->robot_.control(impedance_control_callback);
-
-  } catch (const franka::Exception& ex) {
-    run_loop::running_skills_ = false;
-    std::cerr << ex.what() << std::endl;
-    // Make sure we don't lose data.
-    robot_state_data->writeCurrentBufferData();
-
-    // print last 50 values
-    robot_state_data->printGlobalData(50);
-    robot_state_data->file_logger_thread_.join();
-  }
+  robot->robot_.control(impedance_control_callback);
 }
 
 void SkillInfo::execute_meta_skill_on_franka(FrankaRobot *robot,
@@ -102,67 +89,55 @@ void SkillInfo::execute_meta_skill_on_franka(FrankaRobot *robot,
 void SkillInfo::execute_skill_on_franka_joint_base(FrankaRobot* robot,
                                                    RobotStateData *robot_state_data) {
 
-  try {
-    double time = 0.0;
-    int log_counter = 0;
+  double time = 0.0;
+  int log_counter = 0;
 
-    std::cout << "Will run the control loop\n";
+  std::cout << "Will run the control loop\n";
 
-    franka::Model model = robot->getModel();
+  franka::Model model = robot->getModel();
 
-    // define callback for the torque control loop
-    std::function<franka::Torques(const franka::RobotState&, franka::Duration)>
-        impedance_control_callback = [&, &time](const franka::RobotState& robot_state,
-                                                franka::Duration period) -> franka::Torques {
+  // define callback for the torque control loop
+  std::function<franka::Torques(const franka::RobotState&, franka::Duration)>
+      impedance_control_callback = [&, &time](const franka::RobotState& robot_state,
+                                              franka::Duration period) -> franka::Torques {
 
-      if (time == 0.0) {
-        traj_generator_->initialize_trajectory(robot_state);
-        feedback_controller_->initialize_controller(&model);
-      }
+    if (time == 0.0) {
+      traj_generator_->initialize_trajectory(robot_state);
+      feedback_controller_->initialize_controller(&model);
+    }
 
-      if (robot_state_data->mutex_.try_lock()) {
-        robot_state_data->counter_ += 1;
-        robot_state_data->time_ =  period.toSec();
-        robot_state_data->has_data_ = true;
-        robot_state_data->mutex_.unlock();
-      }
+    if (robot_state_data->mutex_.try_lock()) {
+      robot_state_data->counter_ += 1;
+      robot_state_data->time_ =  period.toSec();
+      robot_state_data->has_data_ = true;
+      robot_state_data->mutex_.unlock();
+    }
 
-      traj_generator_->dt_ = period.toSec();
-      traj_generator_->time_ += period.toSec();
-      time += period.toSec();
-      log_counter += 1;
+    traj_generator_->dt_ = period.toSec();
+    traj_generator_->time_ += period.toSec();
+    time += period.toSec();
+    log_counter += 1;
 
-      traj_generator_->get_next_step();
+    traj_generator_->get_next_step();
 
-      if (log_counter % 1 == 0) {
-        robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
-        robot_state_data->log_robot_state(robot_state, time);
-      }
+    if (log_counter % 1 == 0) {
+      robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
+      robot_state_data->log_robot_state(robot_state, time);
+    }
 
-      feedback_controller_->get_next_step(robot_state, traj_generator_);
+    feedback_controller_->get_next_step(robot_state, traj_generator_);
 
-      bool done = termination_handler_->should_terminate_on_franka(robot_state, traj_generator_);
+    bool done = termination_handler_->should_terminate_on_franka(robot_state, traj_generator_);
 
-      if(done) {
-        return franka::MotionFinished(franka::Torques(feedback_controller_->tau_d_array_));
-      }
+    if(done) {
+      return franka::MotionFinished(franka::Torques(feedback_controller_->tau_d_array_));
+    }
 
 
-      return feedback_controller_->tau_d_array_;
-    };
+    return feedback_controller_->tau_d_array_;
+  };
 
-    robot->robot_.control(impedance_control_callback);
-
-  } catch (const franka::Exception& ex) {
-    run_loop::running_skills_ = false;
-    std::cerr << ex.what() << std::endl;
-    // Make sure we don't lose data.
-    robot_state_data->writeCurrentBufferData();
-
-    // print last 50 values
-    robot_state_data->printGlobalData(50);
-    robot_state_data->file_logger_thread_.join();
-  }
+  robot->robot_.control(impedance_control_callback);
 }
 
 void SkillInfo::execute_skill_on_franka_temp2(FrankaRobot* robot,
@@ -179,231 +154,206 @@ void SkillInfo::execute_skill_on_franka_temp2(FrankaRobot* robot,
   damping.bottomRightCorner(3, 3) << 2.0 * sqrt(rotational_stiffness) *
       Eigen::MatrixXd::Identity(3, 3);
 
-  try {
-    double time = 0.0;
-    int log_counter = 0;
+  double time = 0.0;
+  int log_counter = 0;
 
-    std::cout << "Will run the control loop\n";
+  std::cout << "Will run the control loop\n";
 
-    franka::Model model = robot->getModel();
+  franka::Model model = robot->getModel();
 
-    // define callback for the torque control loop
-    std::function<franka::Torques(const franka::RobotState&, franka::Duration)>
-        impedance_control_callback = [&, &time](const franka::RobotState& robot_state,
-                                                franka::Duration period) -> franka::Torques {
+  // define callback for the torque control loop
+  std::function<franka::Torques(const franka::RobotState&, franka::Duration)>
+      impedance_control_callback = [&, &time](const franka::RobotState& robot_state,
+                                              franka::Duration period) -> franka::Torques {
 
-      if (time == 0.0) {
-        traj_generator_->initialize_trajectory(robot_state);
-      }
+    if (time == 0.0) {
+      traj_generator_->initialize_trajectory(robot_state);
+    }
 
-      if (robot_state_data->mutex_.try_lock()) {
-        robot_state_data->counter_ += 1;
-        robot_state_data->time_ =  period.toSec();
-        robot_state_data->has_data_ = true;
-        robot_state_data->mutex_.unlock();
-      }
+    if (robot_state_data->mutex_.try_lock()) {
+      robot_state_data->counter_ += 1;
+      robot_state_data->time_ =  period.toSec();
+      robot_state_data->has_data_ = true;
+      robot_state_data->mutex_.unlock();
+    }
 
-      traj_generator_->dt_ = period.toSec();
-      traj_generator_->time_ += period.toSec();
-      time += period.toSec();
-      log_counter += 1;
+    traj_generator_->dt_ = period.toSec();
+    traj_generator_->time_ += period.toSec();
+    time += period.toSec();
+    log_counter += 1;
 
-      traj_generator_->get_next_step();
+    traj_generator_->get_next_step();
 
-      bool done = termination_handler_->should_terminate(traj_generator_);
+    bool done = termination_handler_->should_terminate(traj_generator_);
 
-      if (log_counter % 1 == 0) {
-        robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
-        robot_state_data->log_robot_state(robot_state, time);
-      }
+    if (log_counter % 1 == 0) {
+      robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
+      robot_state_data->log_robot_state(robot_state, time);
+    }
 
-      Eigen::Affine3d initial_transform(Eigen::Matrix4d::Map(traj_generator_->pose_desired_.data()));
-      Eigen::Vector3d position_d(initial_transform.translation());
-      Eigen::Quaterniond orientation_d(initial_transform.linear());
+    Eigen::Affine3d initial_transform(Eigen::Matrix4d::Map(traj_generator_->pose_desired_.data()));
+    Eigen::Vector3d position_d(initial_transform.translation());
+    Eigen::Quaterniond orientation_d(initial_transform.linear());
 
-      // get state variables
-      std::array<double, 7> coriolis_array = model.coriolis(robot_state);
-      std::array<double, 42> jacobian_array =
-          model.zeroJacobian(franka::Frame::kEndEffector, robot_state);
+    // get state variables
+    std::array<double, 7> coriolis_array = model.coriolis(robot_state);
+    std::array<double, 42> jacobian_array =
+        model.zeroJacobian(franka::Frame::kEndEffector, robot_state);
 
-      // convert to Eigen
-      Eigen::Map<const Eigen::Matrix<double, 7, 1> > coriolis(coriolis_array.data());
-      Eigen::Map<const Eigen::Matrix<double, 6, 7> > jacobian(jacobian_array.data());
-      Eigen::Map<const Eigen::Matrix<double, 7, 1> > q(robot_state.q.data());
-      Eigen::Map<const Eigen::Matrix<double, 7, 1> > dq(robot_state.dq.data());
-      Eigen::Affine3d transform(Eigen::Matrix4d::Map(robot_state.O_T_EE.data()));
-      Eigen::Vector3d position(transform.translation());
-      Eigen::Quaterniond orientation(transform.linear());
+    // convert to Eigen
+    Eigen::Map<const Eigen::Matrix<double, 7, 1> > coriolis(coriolis_array.data());
+    Eigen::Map<const Eigen::Matrix<double, 6, 7> > jacobian(jacobian_array.data());
+    Eigen::Map<const Eigen::Matrix<double, 7, 1> > q(robot_state.q.data());
+    Eigen::Map<const Eigen::Matrix<double, 7, 1> > dq(robot_state.dq.data());
+    Eigen::Affine3d transform(Eigen::Matrix4d::Map(robot_state.O_T_EE.data()));
+    Eigen::Vector3d position(transform.translation());
+    Eigen::Quaterniond orientation(transform.linear());
 
-      // compute error to desired equilibrium pose
-      // position error
-      Eigen::Matrix<double, 6, 1> error;
-      error.head(3) << position - position_d;
+    // compute error to desired equilibrium pose
+    // position error
+    Eigen::Matrix<double, 6, 1> error;
+    error.head(3) << position - position_d;
 
-      // orientation error
-      // "difference" quaternion
-      if (orientation_d.coeffs().dot(orientation.coeffs()) < 0.0) {
-        orientation.coeffs() << -orientation.coeffs();
-      }
-      Eigen::Quaterniond error_quaternion(orientation * orientation_d.inverse());
-      // convert to axis angle
-      Eigen::AngleAxisd error_quaternion_angle_axis(error_quaternion);
-      // compute "orientation error"
-      error.tail(3) << error_quaternion_angle_axis.axis() * error_quaternion_angle_axis.angle();
+    // orientation error
+    // "difference" quaternion
+    if (orientation_d.coeffs().dot(orientation.coeffs()) < 0.0) {
+      orientation.coeffs() << -orientation.coeffs();
+    }
+    Eigen::Quaterniond error_quaternion(orientation * orientation_d.inverse());
+    // convert to axis angle
+    Eigen::AngleAxisd error_quaternion_angle_axis(error_quaternion);
+    // compute "orientation error"
+    error.tail(3) << error_quaternion_angle_axis.axis() * error_quaternion_angle_axis.angle();
 
-      // compute control
-      Eigen::VectorXd tau_task(7), tau_d(7);
+    // compute control
+    Eigen::VectorXd tau_task(7), tau_d(7);
 
-      // Spring damper system with damping ratio=1
-      tau_task << jacobian.transpose() * (-stiffness * error - damping * (jacobian * dq));
-      tau_d << tau_task + coriolis;
+    // Spring damper system with damping ratio=1
+    tau_task << jacobian.transpose() * (-stiffness * error - damping * (jacobian * dq));
+    tau_d << tau_task + coriolis;
 
-      std::array<double, 7> tau_d_array{};
-      Eigen::VectorXd::Map(&tau_d_array[0], 7) = tau_d;
-      return tau_d_array;
-    };
+    std::array<double, 7> tau_d_array{};
+    Eigen::VectorXd::Map(&tau_d_array[0], 7) = tau_d;
+    return tau_d_array;
+  };
 
-    robot->robot_.control(impedance_control_callback);
-
-  } catch (const franka::Exception& ex) {
-    run_loop::running_skills_ = false;
-    std::cerr << ex.what() << std::endl;
-    // Make sure we don't lose data.
-    robot_state_data->writeCurrentBufferData();
-
-    // print last 50 values
-    robot_state_data->printGlobalData(50);
-    robot_state_data->file_logger_thread_.join();
-  }
+  robot->robot_.control(impedance_control_callback);
 }
 
 void SkillInfo::execute_skill_on_franka_temp(FrankaRobot* robot,
                                              RobotStateData *robot_state_data) {
-  try {
-    double time = 0.0;
-    int log_counter = 0;
+  double time = 0.0;
+  int log_counter = 0;
 
+  std::cout << "Will run the control loop\n";
+  std::function<franka::CartesianPose(const franka::RobotState&, franka::Duration)> cartesian_pose_callback =
+      [=, &time, &log_counter](const franka::RobotState& robot_state,
+                                franka::Duration period) -> franka::CartesianPose {
+        if (time == 0.0) {
+          traj_generator_->initialize_trajectory(robot_state);
+        }
 
-    std::cout << "Will run the control loop\n";
-    std::function<franka::CartesianPose(const franka::RobotState&, franka::Duration)> cartesian_pose_callback =
-        [=, &time, &log_counter](const franka::RobotState& robot_state,
-                                 franka::Duration period) -> franka::CartesianPose {
-          if (time == 0.0) {
-            traj_generator_->initialize_trajectory(robot_state);
-          }
+        if (robot_state_data->mutex_.try_lock()) {
+          robot_state_data->counter_ += 1;
+          robot_state_data->time_ =  period.toSec();
+          robot_state_data->has_data_ = true;
+          robot_state_data->mutex_.unlock();
+        }
 
-          if (robot_state_data->mutex_.try_lock()) {
-            robot_state_data->counter_ += 1;
-            robot_state_data->time_ =  period.toSec();
-            robot_state_data->has_data_ = true;
-            robot_state_data->mutex_.unlock();
-          }
+        traj_generator_->dt_ = period.toSec();
+        traj_generator_->time_ += period.toSec();
+        time += period.toSec();
+        log_counter += 1;
 
-          traj_generator_->dt_ = period.toSec();
-          traj_generator_->time_ += period.toSec();
-          time += period.toSec();
-          log_counter += 1;
+        traj_generator_->get_next_step();
 
-          traj_generator_->get_next_step();
+        bool done = termination_handler_->should_terminate(traj_generator_);
 
-          bool done = termination_handler_->should_terminate(traj_generator_);
+        franka::CartesianPose pose_desired(traj_generator_->pose_desired_);
+        if (log_counter % 1 == 0) {
+          robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
+          robot_state_data->log_robot_state(robot_state, time);
+        }
 
-          franka::CartesianPose pose_desired(traj_generator_->pose_desired_);
-          if (log_counter % 1 == 0) {
-            robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
-            robot_state_data->log_robot_state(robot_state, time);
-          }
+        if(done or time >= traj_generator_->run_time_ + traj_generator_->acceleration_time_)
+        {
+          return franka::MotionFinished(pose_desired);
+        }
 
-          if(done or time >= traj_generator_->run_time_ + traj_generator_->acceleration_time_)
-          {
-            return franka::MotionFinished(pose_desired);
-          }
+        return pose_desired;
+      };
 
-          return pose_desired;
-        };
-
-    std::function<franka::JointPositions(const franka::RobotState&, franka::Duration)>
-        joint_pose_callback = [=, &time, &log_counter](
-            const franka::RobotState& robot_state,
-            franka::Duration period) -> franka::JointPositions {
-      if (time == 0.0) {
-        traj_generator_->initialize_trajectory(robot_state);
-      }
-      time += period.toSec();
-      traj_generator_->time_ = time;
-      traj_generator_->dt_ = period.toSec();
-      traj_generator_->get_next_step();
-
-      bool done = termination_handler_->should_terminate(traj_generator_);
-      franka::JointPositions joint_desired(traj_generator_->joint_desired_);
-
-      log_counter += 1;
-      if (log_counter % 1 == 0) {
-        robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
-        robot_state_data->log_robot_state(robot_state, time);
-      }
-
-      if(done or time >= traj_generator_->run_time_) {
-        return franka::MotionFinished(joint_desired);
-      }
-      return joint_desired;
-    };
-
-    franka::Model model = robot->getModel();
-
-    std::array<double, 7> q_goal = {{0, -M_PI_4, 0, -3 * M_PI_4, 0, M_PI_2, M_PI_4}};
-    std::function<franka::Torques(const franka::RobotState&, franka::Duration)> impedance_control_callback =
-        [=, &model, &q_goal](
-            const franka::RobotState& state, franka::Duration /*period*/) -> franka::Torques {
-          // Read current coriolis terms from model.
-          std::array<double, 7> coriolis = model.coriolis(state);
-
-          // Compute torque command from joint impedance control law.
-          // Note: The answer to our Cartesian pose inverse kinematics is always in state.q_d with one
-          // time step delay.
-          std::array<double, 7> tau_d_calculated;
-          for (size_t i = 0; i < 7; i++) {
-            tau_d_calculated[i] =
-                k_gains_[i] * (state.q_d[i] - state.q[i]) - d_gains_[i] * state.dq[i] + coriolis[i];
-            // tau_d_calculated[i] =
-            //     k_gains_[i] * (q_goal[i] - state.q[i]) - d_gains_[i] * state.dq[i] + coriolis[i];
-          }
-
-          // The following line is only necessary for printing the rate limited torque. As we activated
-          // rate limiting for the control loop (activated by default), the torque would anyway be
-          // adjusted!
-          std::array<double, 7> tau_d_rate_limited =
-              franka::limitRate(franka::kMaxTorqueRate, tau_d_calculated, state.tau_J_d);
-
-          // Send torque command.
-          return tau_d_rate_limited;
-        };
-
-
-    /*int memory_index = run_loop_info_->get_current_shared_memory_index();
-    SharedBuffer buffer = execution_feedback_buffer_0_;
-    if (memory_index == 1) {
-      buffer = execution_feedback_buffer_1_;
+  std::function<franka::JointPositions(const franka::RobotState&, franka::Duration)>
+      joint_pose_callback = [=, &time, &log_counter](
+          const franka::RobotState& robot_state,
+          franka::Duration period) -> franka::JointPositions {
+    if (time == 0.0) {
+      traj_generator_->initialize_trajectory(robot_state);
     }
-    skill->write_feedback_to_shared_memory(buffer);
+    time += period.toSec();
+    traj_generator_->time_ = time;
+    traj_generator_->dt_ = period.toSec();
+    traj_generator_->get_next_step();
 
-    robot->robot_.control()*/
+    bool done = termination_handler_->should_terminate(traj_generator_);
+    franka::JointPositions joint_desired(traj_generator_->joint_desired_);
 
-    // robot->robot_.control(impedance_control_callback, cartesian_pose_callback);
-    // robot->robot_.control(cartesian_pose_callback, franka::ControllerMode::kCartesianImpedance, true, 1000.0);
-    // robot->robot_.control(impedance_control_callback, joint_pose_callback);
-    robot->robot_.control(impedance_control_callback);
+    log_counter += 1;
+    if (log_counter % 1 == 0) {
+      robot_state_data->log_pose_desired(traj_generator_->pose_desired_);
+      robot_state_data->log_robot_state(robot_state, time);
+    }
 
-  } catch (const franka::Exception& ex) {
-    run_loop::running_skills_ = false;
-    std::cerr << ex.what() << std::endl;
-    // Make sure we don't lose data.
-    robot_state_data->writeCurrentBufferData();
+    if(done or time >= traj_generator_->run_time_) {
+      return franka::MotionFinished(joint_desired);
+    }
+    return joint_desired;
+  };
 
-    // print last 50 values
-    robot_state_data->printGlobalData(50);
-    robot_state_data->file_logger_thread_.join();
+  franka::Model model = robot->getModel();
+
+  std::array<double, 7> q_goal = {{0, -M_PI_4, 0, -3 * M_PI_4, 0, M_PI_2, M_PI_4}};
+  std::function<franka::Torques(const franka::RobotState&, franka::Duration)> impedance_control_callback =
+      [=, &model, &q_goal](
+          const franka::RobotState& state, franka::Duration /*period*/) -> franka::Torques {
+        // Read current coriolis terms from model.
+        std::array<double, 7> coriolis = model.coriolis(state);
+
+        // Compute torque command from joint impedance control law.
+        // Note: The answer to our Cartesian pose inverse kinematics is always in state.q_d with one
+        // time step delay.
+        std::array<double, 7> tau_d_calculated;
+        for (size_t i = 0; i < 7; i++) {
+          tau_d_calculated[i] =
+              k_gains_[i] * (state.q_d[i] - state.q[i]) - d_gains_[i] * state.dq[i] + coriolis[i];
+          // tau_d_calculated[i] =
+          //     k_gains_[i] * (q_goal[i] - state.q[i]) - d_gains_[i] * state.dq[i] + coriolis[i];
+        }
+
+        // The following line is only necessary for printing the rate limited torque. As we activated
+        // rate limiting for the control loop (activated by default), the torque would anyway be
+        // adjusted!
+        std::array<double, 7> tau_d_rate_limited =
+            franka::limitRate(franka::kMaxTorqueRate, tau_d_calculated, state.tau_J_d);
+
+        // Send torque command.
+        return tau_d_rate_limited;
+      };
+
+
+  /*int memory_index = run_loop_info_->get_current_shared_memory_index();
+  SharedBuffer buffer = execution_feedback_buffer_0_;
+  if (memory_index == 1) {
+    buffer = execution_feedback_buffer_1_;
   }
+  skill->write_feedback_to_shared_memory(buffer);
+
+  robot->robot_.control()*/
+
+  // robot->robot_.control(impedance_control_callback, cartesian_pose_callback);
+  // robot->robot_.control(cartesian_pose_callback, franka::ControllerMode::kCartesianImpedance, true, 1000.0);
+  // robot->robot_.control(impedance_control_callback, joint_pose_callback);
+  robot->robot_.control(impedance_control_callback);
 }
 
 bool SkillInfo::should_terminate() {

--- a/iam_robolib_common/include/iam_robolib_common/SharedMemoryInfo.h
+++ b/iam_robolib_common/include/iam_robolib_common/SharedMemoryInfo.h
@@ -75,8 +75,8 @@ class SharedMemoryInfo {
    */
   int getSizeForExecutionFeedbackData();
   int getOffsetForExecutionFeedbackData();
-  int getSizeForExecutionReturnData();
-  int getOffsetForExecutionReturnData();
+  int getSizeForExecutionResultData();
+  int getOffsetForExecutionResultData();
 
 
  private:
@@ -120,7 +120,7 @@ class SharedMemoryInfo {
   const int extra_sensor_data_buffer_size_ = 1024 * sizeof(float);
 
   const int execution_response_feedback_size_= 1024 * sizeof(float);
-  const int execution_response_return_size_= 1024 * sizeof(float);
+  const int execution_response_result_size_= 1024 * sizeof(float);
 
   const int current_robot_state_size_= 300 * sizeof(float);
 

--- a/iam_robolib_common/include/iam_robolib_common/run_loop_process_info.h
+++ b/iam_robolib_common/include/iam_robolib_common/run_loop_process_info.h
@@ -144,6 +144,20 @@ class RunLoopProcessInfo {
   */
   void set_result_skill_id(int result_skill_id);
 
+  bool get_is_ready();
+  void set_is_ready(bool is_ready);
+
+  int get_watchdog_counter();
+  void reset_watchdog_counter(); // to be used by robolib
+  void increment_watchdog_counter(); // to be used by franka_actionlib
+
+  std::string get_error_description();
+  void set_error_description(std::string description); // to be used by robolib
+  void clear_error_description(); // to be used by franka_actionlib
+
+  // reset internal variables about skills to their default values. used by robolib for error recovery
+  void reset_skill_vars();
+
  private:
   bool new_skill_available_{false};
   int new_skill_type_{0};
@@ -152,17 +166,22 @@ class RunLoopProcessInfo {
   bool is_running_skill_{false};
   bool skill_preempted_{false};
 
-  int current_memory_region_{1};
+  int current_memory_region_{1}; 
   int current_sensor_region_{1};
   int current_feedback_region_{1};
-  int current_skill_id_{-1};
+  int current_skill_id_{-1}; 
   int new_skill_id_{-1};
   int done_skill_id_{-1};
   int result_skill_id_{-1};
   char new_skill_description_[1000];
-  size_t new_skill_description_len_=1;
+  size_t new_skill_description_len_=0;
 
   int current_meta_skill_id_{-1};
   int new_meta_skill_id_{-1};
+
+  bool is_ready_{false};
+  int watchdog_counter_{0};
+  char error_description_[1000];
+  size_t error_description_len_=0;
 };
 

--- a/iam_robolib_common/include/iam_robolib_common/run_loop_process_info.h
+++ b/iam_robolib_common/include/iam_robolib_common/run_loop_process_info.h
@@ -174,7 +174,7 @@ class RunLoopProcessInfo {
   int done_skill_id_{-1};
   int result_skill_id_{-1};
   char new_skill_description_[1000];
-  size_t new_skill_description_len_=0;
+  size_t new_skill_description_len_=1;
 
   int current_meta_skill_id_{-1};
   int new_meta_skill_id_{-1};

--- a/iam_robolib_common/src/SharedMemoryInfo.cpp
+++ b/iam_robolib_common/src/SharedMemoryInfo.cpp
@@ -117,7 +117,7 @@ int SharedMemoryInfo::getObjectMemorySize() {
 }
 
 int SharedMemoryInfo::getExecutionResponseMemorySize() {
-  return execution_response_feedback_size_ + execution_response_return_size_;
+  return execution_response_feedback_size_ + execution_response_result_size_;
 }
 
 int SharedMemoryInfo::getCurrentRobotStateMemorySize() {
@@ -211,11 +211,11 @@ int SharedMemoryInfo::getOffsetForExecutionFeedbackData() {
   return 0;
 }
 
-int SharedMemoryInfo::getSizeForExecutionReturnData() {
-  return execution_response_return_size_;
+int SharedMemoryInfo::getSizeForExecutionResultData() {
+  return execution_response_result_size_;
 }
 
-int SharedMemoryInfo::getOffsetForExecutionReturnData() {
+int SharedMemoryInfo::getOffsetForExecutionResultData() {
   return execution_response_feedback_size_;
 }
 

--- a/iam_robolib_common/src/run_loop_process_info.cpp
+++ b/iam_robolib_common/src/run_loop_process_info.cpp
@@ -162,3 +162,60 @@ void RunLoopProcessInfo::set_result_skill_id(int result_skill_id) {
          result_skill_id == (done_skill_id_ - 1));
   result_skill_id_ = result_skill_id;
 }
+
+bool RunLoopProcessInfo::get_is_ready() {
+  return is_ready_;
+}
+
+void RunLoopProcessInfo::set_is_ready(bool is_ready) {
+  is_ready_ = is_ready;
+}
+
+int RunLoopProcessInfo::get_watchdog_counter() {
+  return watchdog_counter_;
+}
+
+void RunLoopProcessInfo::reset_watchdog_counter() {
+  watchdog_counter_ = 0;
+}
+
+void RunLoopProcessInfo::increment_watchdog_counter() {
+  watchdog_counter_ ++;
+}
+
+std::string RunLoopProcessInfo::get_error_description() {
+  std::string desc(error_description_,
+                   error_description_ + sizeof(error_description_[0]) * error_description_len_);
+  return desc;
+}
+
+void RunLoopProcessInfo::set_error_description(std::string description){  
+  std::memcpy(&error_description_, description.c_str(), description.size());
+  error_description_len_  = description.size();
+}
+
+void RunLoopProcessInfo::clear_error_description() {  
+  set_error_description("");
+}
+
+void RunLoopProcessInfo::reset_skill_vars() {
+  new_skill_available_ = false;
+  new_skill_type_ = 0;
+  new_meta_skill_type_ = 0;
+
+  is_running_skill_ = false;
+  skill_preempted_ = false;
+
+  current_memory_region_ = 1;
+  current_sensor_region_ = 1;
+  current_feedback_region_ = 1;
+  current_skill_id_ = -1;
+  new_skill_id_ = -1;
+  done_skill_id_ = -1;
+  result_skill_id_ = -1;
+  memset(new_skill_description_, 0, sizeof new_skill_description_);
+  new_skill_description_len_ = 0;
+
+  current_meta_skill_id_ = -1;
+  new_meta_skill_id_ = -1;
+}

--- a/src/catkin_ws/src/franka_action_lib/CMakeLists.txt
+++ b/src/catkin_ws/src/franka_action_lib/CMakeLists.txt
@@ -65,6 +65,7 @@ LINK_DIRECTORIES(${iam_robolib_common_lib})
 add_message_files(
   FILES
   RobotState.msg
+  RobolibStatus.msg
 )
 
 ## Generate services in the 'srv' folder
@@ -150,6 +151,7 @@ add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EX
 add_executable(example_execute_skill_action_client_node src/example_execute_skill_action_client.cpp)
 add_executable(execute_skill_action_server_node src/execute_skill_action_server.cpp src/execute_skill_action_server_node.cpp)
 add_executable(robot_state_publisher_node src/robot_state_publisher.cpp src/robot_state_publisher_node.cpp)
+add_executable(robolib_status_publisher_node src/robolib_status_publisher.cpp src/robolib_status_publisher_node.cpp)
 
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -181,6 +183,15 @@ target_link_libraries(
 )
 target_link_libraries(
   robot_state_publisher_node
+  Threads::Threads
+  ${Boost_LIBRARIES}
+  ${catkin_LIBRARIES}
+  rt
+  iam_robolib_common
+  ${PROJECT_NAME}
+)
+target_link_libraries(
+  robolib_status_publisher_node
   Threads::Threads
   ${Boost_LIBRARIES}
   ${catkin_LIBRARIES}

--- a/src/catkin_ws/src/franka_action_lib/frankapy/exceptions.py
+++ b/src/catkin_ws/src/franka_action_lib/frankapy/exceptions.py
@@ -1,12 +1,23 @@
 class FrankaArmCommException(Exception):
-    """ Communication failure. Usually occurs due to timeouts.
-    """
+    ''' Communication failure. Usually occurs due to timeouts.
+    '''
+    def __init__(self, message, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+        self.message = message
+    
+    def __str__(self):
+        return "Communication w/ Robolib ran into a problem: {}. Robolib is probably not ready.".format(self.message)
+
+class FrankaArmRobolibNotReadyException(Exception):
+    ''' Exception for when robolib is not ready
+    '''
+
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
 
 class FrankaArmCollisionException(Exception):
-    """ Failure of control, typically due to a kinematically unreachable pose.
-    """
+    ''' Failure of control, typically due to a kinematically unreachable pose.
+    '''
 
     def __init__(self, cmd, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
@@ -14,3 +25,14 @@ class FrankaArmCollisionException(Exception):
 
     def __str__(self):
         return "Command resulted in a collision! Got params {}".format(self.cmd)
+
+class FrankaArmException(Exception):
+    ''' Failure of control, typically due to a kinematically unreachable pose.
+    '''
+
+    def __init__(self, message, *args, **kwargs):
+        Exception.__init__(self, *args, **kwargs)
+        self.message = message
+
+    def __str__(self):
+        return "Robolib ran into a problem: {}".format(self.message)

--- a/src/catkin_ws/src/franka_action_lib/frankapy/franka_constants.py
+++ b/src/catkin_ws/src/franka_action_lib/frankapy/franka_constants.py
@@ -26,3 +26,9 @@ class FrankaConstants:
 
     MAX_FORCE_NORM = 20
     MAX_TORQUE_NORM = 2
+
+    ROS_ROBOLIB_STATUS_PUBLISHER_NAME = '/robolib_status_publisher_node/robolib_status'
+    ROS_EXECUTE_SKILL_ACTION_SERVER_NAME = '/execute_skill_action_server_node/execute_skill'
+
+    DEFAULT_ROBOLIB_TIMEOUT = 5 # in seconds
+    ACTION_WAIT_LOOP_TIME = 0.001

--- a/src/catkin_ws/src/franka_action_lib/include/franka_action_lib/execute_skill_action_server.h
+++ b/src/catkin_ws/src/franka_action_lib/include/franka_action_lib/execute_skill_action_server.h
@@ -8,6 +8,7 @@
 #include <vector>
 #include <ros/ros.h>
 #include <franka_action_lib/ExecuteSkillAction.h> // Note: "Action" is appended
+#include <franka_action_lib/RobolibStatus.h>
 #include <actionlib/server/simple_action_server.h>
 
 #include "franka_action_lib/shared_memory_handler.h"
@@ -29,6 +30,7 @@ namespace franka_action_lib
       franka_action_lib::ExecuteSkillResult result_;
 
       franka_action_lib::SharedMemoryHandler shared_memory_handler_;
+      franka_action_lib::RobolibStatus robolib_status_;
 
     public:
 

--- a/src/catkin_ws/src/franka_action_lib/include/franka_action_lib/robolib_status_publisher.h
+++ b/src/catkin_ws/src/franka_action_lib/include/franka_action_lib/robolib_status_publisher.h
@@ -26,7 +26,7 @@ namespace franka_action_lib
       int stale_count = 0;
 
       double publish_frequency_;
-      franka_action_lib::SharedMemoryHandler shared_memory_handler_;
+      franka_action_lib::SharedMemoryHandler *shared_memory_handler_;
 
     public:
 

--- a/src/catkin_ws/src/franka_action_lib/include/franka_action_lib/robolib_status_publisher.h
+++ b/src/catkin_ws/src/franka_action_lib/include/franka_action_lib/robolib_status_publisher.h
@@ -1,0 +1,40 @@
+#ifndef FRANKA_ACTION_LIB_ROBOT_STATE_PUBLISHER_H
+#define FRANKA_ACTION_LIB_ROBOT_STATE_PUBLISHER_H
+
+#include <iostream>
+#include <thread>
+#include <array>
+#include <chrono>
+#include <vector>
+#include <ros/ros.h>
+
+#include "franka_action_lib/RobolibStatus.h"
+#include "franka_action_lib/shared_memory_handler.h"
+
+namespace franka_action_lib  
+{ 
+  class RobolibStatusPublisher
+  {
+    protected:
+
+      ros::NodeHandle nh_;
+      ros::Publisher robolib_status_pub_; // NodeHandle instance must be created before this line. Otherwise strange error occurs.
+      std::string topic_name_;
+
+      RobolibStatus last_robolib_status_;
+      bool has_seen_one_robolib_status_;
+      int stale_count = 0;
+
+      double publish_frequency_;
+      franka_action_lib::SharedMemoryHandler shared_memory_handler_;
+
+    public:
+
+      RobolibStatusPublisher(std::string name);
+
+      ~RobolibStatusPublisher(void){}
+
+  };
+}
+
+#endif // FRANKA_ACTION_LIB_ROBOT_STATE_PUBLISHER_H

--- a/src/catkin_ws/src/franka_action_lib/include/franka_action_lib/shared_memory_handler.h
+++ b/src/catkin_ws/src/franka_action_lib/include/franka_action_lib/shared_memory_handler.h
@@ -3,6 +3,7 @@
 
 #include <franka_action_lib/ExecuteSkillAction.h> // Note: "Action" is appended
 #include <franka_action_lib/RobotState.h>
+#include <franka_action_lib/RobolibStatus.h>
 
 #include "ros/ros.h" // For ROS::ERROR messages
 
@@ -45,10 +46,14 @@ namespace franka_action_lib
       franka_action_lib::ExecuteSkillResult getSkillResult(int skill_id);
 
       franka_action_lib::RobotState getRobotState();
+
+      franka_action_lib::RobolibStatus getRobolibStatus();
       
       bool getNewSkillAvailableFlagInSharedMemory();
 
       int getNewSkillIdInSharedMemory();
+
+      void incrementWatchdogCounter();
 
     private:
 
@@ -150,7 +155,6 @@ namespace franka_action_lib
       void loadFeedbackControllerParamsUnprotected(const franka_action_lib::ExecuteSkillGoalConstPtr &goal, int current_free_shared_memory_index);
       void loadTerminationParamsUnprotected(const franka_action_lib::ExecuteSkillGoalConstPtr &goal, int current_free_shared_memory_index);
       void loadTimerParamsUnprotected(const franka_action_lib::ExecuteSkillGoalConstPtr &goal, int current_free_shared_memory_index);
-      
   };
 }
 

--- a/src/catkin_ws/src/franka_action_lib/launch/franka_ros_interface.launch
+++ b/src/catkin_ws/src/franka_action_lib/launch/franka_ros_interface.launch
@@ -7,5 +7,9 @@
   <node pkg="franka_action_lib" type="robot_state_publisher_node" name="robot_state_publisher_node" output="screen">
     <param name="publish_frequency" value="100" />
   </node>
-
+  
+  <node pkg="franka_action_lib" type="robolib_status_publisher_node" name="robolib_status_publisher_node" output="screen">
+    <param name="publish_frequency" value="100" />
+  </node>
+  
 </launch>

--- a/src/catkin_ws/src/franka_action_lib/msg/RobolibStatus.msg
+++ b/src/catkin_ws/src/franka_action_lib/msg/RobolibStatus.msg
@@ -1,0 +1,5 @@
+# Franka robot state
+std_msgs/Header header
+bool is_ready
+string error_description
+bool is_fresh

--- a/src/catkin_ws/src/franka_action_lib/src/robolib_status_publisher.cpp
+++ b/src/catkin_ws/src/franka_action_lib/src/robolib_status_publisher.cpp
@@ -1,0 +1,50 @@
+#include "franka_action_lib/robolib_status_publisher.h"
+
+namespace franka_action_lib
+{
+  RobolibStatusPublisher::RobolibStatusPublisher(std::string name) :  nh_("~"),
+                                                                topic_name_(name),
+                                                                shared_memory_handler_()
+  {
+    nh_.param("publish_frequency", publish_frequency_, (double) 100.0);
+    robolib_status_pub_ = nh_.advertise<franka_action_lib::RobolibStatus>(topic_name_, 100);
+
+    ROS_INFO("Robolib Status Publisher Started");
+
+    ros::Rate loop_rate(publish_frequency_);
+    while (ros::ok())
+    {
+        // get robolib
+        RobolibStatus robolib_status_ = shared_memory_handler_.getRobolibStatus();
+
+        if (robolib_status_.is_fresh) {
+          last_robolib_status_ = robolib_status_;
+          stale_count = 0;
+          has_seen_one_robolib_status_ = true;
+        } else {
+          // use previous robolib_status if available
+          if (has_seen_one_robolib_status_) {
+            robolib_status_ = last_robolib_status_;
+            stale_count++;
+          }
+        }
+
+        // only proceed if received at least 1 robolib status
+        if (has_seen_one_robolib_status_) {
+          // TODO(jacky): MAGIC NUMBER - Signal not ok if 10 consecutive robolib statuses have been stale. Roughly 100 ms
+          if (stale_count > 10) {
+            robolib_status_.is_ready = false;
+          }
+
+          // publish
+          robolib_status_pub_.publish(robolib_status_);
+
+          // increment watchdog counter
+          shared_memory_handler_.incrementWatchdogCounter();
+        }
+
+        ros::spinOnce();
+        loop_rate.sleep();
+    }
+  }
+}

--- a/src/catkin_ws/src/franka_action_lib/src/robolib_status_publisher.cpp
+++ b/src/catkin_ws/src/franka_action_lib/src/robolib_status_publisher.cpp
@@ -3,11 +3,12 @@
 namespace franka_action_lib
 {
   RobolibStatusPublisher::RobolibStatusPublisher(std::string name) :  nh_("~"),
-                                                                topic_name_(name),
-                                                                shared_memory_handler_()
+                                                                topic_name_(name)
   {
     nh_.param("publish_frequency", publish_frequency_, (double) 100.0);
     robolib_status_pub_ = nh_.advertise<franka_action_lib::RobolibStatus>(topic_name_, 100);
+
+    shared_memory_handler_ = new franka_action_lib::SharedMemoryHandler();
 
     ROS_INFO("Robolib Status Publisher Started");
 
@@ -15,7 +16,7 @@ namespace franka_action_lib
     while (ros::ok())
     {
         // get robolib
-        RobolibStatus robolib_status_ = shared_memory_handler_.getRobolibStatus();
+        RobolibStatus robolib_status_ = shared_memory_handler_->getRobolibStatus();
 
         if (robolib_status_.is_fresh) {
           last_robolib_status_ = robolib_status_;
@@ -40,7 +41,7 @@ namespace franka_action_lib
           robolib_status_pub_.publish(robolib_status_);
 
           // increment watchdog counter
-          shared_memory_handler_.incrementWatchdogCounter();
+          shared_memory_handler_->incrementWatchdogCounter();
         }
 
         ros::spinOnce();

--- a/src/catkin_ws/src/franka_action_lib/src/robolib_status_publisher_node.cpp
+++ b/src/catkin_ws/src/franka_action_lib/src/robolib_status_publisher_node.cpp
@@ -1,0 +1,11 @@
+#include <ros/ros.h>
+#include "franka_action_lib/robolib_status_publisher.h"
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "robolib_status_publisher_node", ros::init_options::AnonymousName);
+
+  franka_action_lib::RobolibStatusPublisher robolib_status_publisher("robolib_status");
+
+  return 0;
+}

--- a/src/catkin_ws/src/franka_action_lib/src/shared_memory_handler.cpp
+++ b/src/catkin_ws/src/franka_action_lib/src/shared_memory_handler.cpp
@@ -231,8 +231,8 @@ namespace franka_action_lib
     execution_result_region_0_ = boost::interprocess::mapped_region(
         shared_execution_result_0_,
         boost::interprocess::read_write,
-        shared_memory_info_.getOffsetForExecutionReturnData(),
-        shared_memory_info_.getSizeForExecutionReturnData()
+        shared_memory_info_.getOffsetForExecutionResultData(),
+        shared_memory_info_.getSizeForExecutionResultData()
         );
     execution_result_buffer_0_ = reinterpret_cast<float *>(execution_result_region_0_.get_address());
 
@@ -262,8 +262,8 @@ namespace franka_action_lib
     execution_result_region_1_ = boost::interprocess::mapped_region(
         shared_execution_result_1_,
         boost::interprocess::read_write,
-        shared_memory_info_.getOffsetForExecutionReturnData(),
-        shared_memory_info_.getSizeForExecutionReturnData()
+        shared_memory_info_.getOffsetForExecutionResultData(),
+        shared_memory_info_.getSizeForExecutionResultData()
     );
     execution_result_buffer_1_ = reinterpret_cast<float *>(execution_result_region_1_.get_address());
 
@@ -534,6 +534,37 @@ namespace franka_action_lib
     robot_state.skill_description = run_loop_process_info_->get_new_skill_description();
 
     return robot_state;
+  }
+
+  franka_action_lib::RobolibStatus SharedMemoryHandler::getRobolibStatus()
+  {
+    boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> run_loop_info_lock(*run_loop_info_mutex_, boost::interprocess::defer_lock);
+
+    franka_action_lib::RobolibStatus robolib_status;
+    robolib_status.header.stamp = ros::Time::now();
+
+    if (run_loop_info_lock.try_lock()) {
+      // TODO(jacky): 10 roughly equates to 100ms of disconnect from the robolib. This should be placed in a global config file.
+      if (run_loop_process_info_->get_watchdog_counter() > 10) {
+        robolib_status.is_ready = false;
+      } else {
+        robolib_status.is_ready = run_loop_process_info_->get_is_ready();
+      }
+      robolib_status.error_description = run_loop_process_info_->get_error_description();
+      robolib_status.is_fresh = true;
+    } else {
+      robolib_status.is_fresh = false;
+    }
+    
+    return robolib_status;
+  }
+
+  void SharedMemoryHandler::incrementWatchdogCounter()
+  {
+    boost::interprocess::scoped_lock<boost::interprocess::interprocess_mutex> run_loop_info_lock(*run_loop_info_mutex_, boost::interprocess::defer_lock);
+    if (run_loop_info_lock.try_lock()) {
+      run_loop_process_info_->increment_watchdog_counter();
+    }
   }
   
   bool SharedMemoryHandler::getNewSkillAvailableFlagInSharedMemory()

--- a/src/catkin_ws/src/franka_action_lib/src/shared_memory_handler.cpp
+++ b/src/catkin_ws/src/franka_action_lib/src/shared_memory_handler.cpp
@@ -544,8 +544,8 @@ namespace franka_action_lib
     robolib_status.header.stamp = ros::Time::now();
 
     if (run_loop_info_lock.try_lock()) {
-      // TODO(jacky): 10 roughly equates to 100ms of disconnect from the robolib. This should be placed in a global config file.
-      if (run_loop_process_info_->get_watchdog_counter() > 10) {
+      // TODO(jacky): 25 roughly equates to 500ms of disconnect from the robolib. This should be placed in a global config file.
+      if (run_loop_process_info_->get_watchdog_counter() > 25) {
         robolib_status.is_ready = false;
       } else {
         robolib_status.is_ready = run_loop_process_info_->get_is_ready();


### PR DESCRIPTION
- expose franka's automatic error recovery function to robot abstract…
- added functions to clear robot state buffers, shared memory buffer, skill lists,
- added functions to create and send RobolibStatus from robolib and corresponding ROS handles to check whether or not robolib is ready. ready is set to false before init finishes and during err recovery.
- added watchdog mechanism through shared memory. robolib resets watch dog to 0, while franka_action_lib increments. when counter gets too high status becomes not ready
- wrapped run_loop's main functionality in while true and try-catch that resets relevant buffers, handles errors, and continue to next iteratino
- removed try-catch from skills as FrankaException is now caught in run_loop
- on franka_action_lib, set skill to be pre-empted if robolib became not ready mid-skill
- on Python side, added appropriate exception raising, handling timeouts, and checking RobolibStatus from ROS
- removed start time from run_loop