### PR TITLE
Flipping running skills flag appropriately to allow robot save data t…

### DIFF
--- a/iam_robolib/include/iam_robolib/run_loop.h
+++ b/iam_robolib/include/iam_robolib/run_loop.h
@@ -132,11 +132,11 @@ class run_loop {
   void finish_current_skill(BaseSkill* skill);
 
   static std::atomic<bool> run_loop_ok_;
-  static std::atomic<bool> running_skill_;
 
  private:
 
   Robot *robot_;
+  static std::mutex robot_access_mutex_;
 
   std::thread robot_state_read_thread_{};
   std::thread current_robot_state_io_thread_{};

--- a/iam_robolib/src/run_loop.cpp
+++ b/iam_robolib/src/run_loop.cpp
@@ -603,12 +603,17 @@ void run_loop::run_on_franka() {
           if (!meta_skill->isComposableSkill() && !skill->get_termination_handler()->done_) {
             // Execute skill.
             log_skill_info(skill);
+            running_skill_ = true;
             meta_skill->execute_skill_on_franka(this, dynamic_cast<FrankaRobot* >(robot_), robot_state_data_);
+            running_skill_ = false;
           } else if (meta_skill->isComposableSkill()) {
             log_skill_info(skill);
+            running_skill_ = true;
             meta_skill->execute_skill_on_franka(this, dynamic_cast<FrankaRobot* >(robot_), robot_state_data_);
+            running_skill_ = false;
           } else {
             finish_current_skill(skill);
+            running_skill_ = false;
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
           }
         }
@@ -622,6 +627,7 @@ void run_loop::run_on_franka() {
           std::cout << "Will start skill\n";
           running_skill_ = true;
           start_new_skill(new_skill);
+          running_skill_ = false;
         }
 
         // Sleep to maintain 1Khz frequency, not sure if this is required or not.

--- a/iam_robolib/src/run_loop.cpp
+++ b/iam_robolib/src/run_loop.cpp
@@ -318,11 +318,9 @@ void run_loop::setup_save_robot_state_thread() {
 
         // Try to lock data to avoid read write collisions.
         if (robot_access_mutex_.try_lock()) {
-          switch(robot_->robot_type_)
-          {
+          switch (robot_->robot_type_) {
             case RobotType::FRANKA: {
                 try {
-                  printf("save thread: getting, saving robot data\n");
                   FrankaRobot* franka_robot = dynamic_cast<FrankaRobot* >(robot_);
                   franka::RobotState robot_state = franka_robot->getRobotState();
                   franka::GripperState gripper_state = franka_robot->getGripperState();
@@ -337,8 +335,8 @@ void run_loop::setup_save_robot_state_thread() {
                   robot_access_mutex_.unlock();
                   std::cerr << "Robot state save thread encountered Franka exception. Will not log for now.\n";
                 }
+                break;
               }
-              break;
             case RobotType::UR5E:
               break;
           }

--- a/iam_robolib/src/run_loop.cpp
+++ b/iam_robolib/src/run_loop.cpp
@@ -27,7 +27,7 @@
 #include "iam_robolib/skills/force_torque_skill.h"
 
 std::atomic<bool> run_loop::run_loop_ok_{false};
-std::atomic<bool> run_loop::running_skill_{false};
+std::mutex run_loop::robot_access_mutex_;
 
 template<typename ... Args>
 std::string string_format(const std::string& format, Args ... args )
@@ -303,7 +303,7 @@ void run_loop::run() {
 }
 
 void run_loop::setup_save_robot_state_thread() {
-  int io_rate = 100;   // The below thread will print at 10 FPS.
+  int io_rate = 100;   // The below thread will print at 100 FPS.
   robot_state_read_thread_ = std::thread([&, io_rate]() {
       // Sleep to achieve the desired print rate.
       std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
@@ -311,29 +311,32 @@ void run_loop::setup_save_robot_state_thread() {
         std::this_thread::sleep_for(
             std::chrono::milliseconds(static_cast<int>((1.0 / io_rate * 1000.0))));
 
-        // don't record data if a skill is running - the skill's control loop will handle that.
-        if (!run_loop_ok_ || running_skill_) {
+        // don't record data if run loop is not ready
+        if (!run_loop_ok_) {
           continue;
         }
 
         // Try to lock data to avoid read write collisions.
-        switch(robot_->robot_type_)
-        {
-          case RobotType::FRANKA: {
-              FrankaRobot* franka_robot = dynamic_cast<FrankaRobot* >(robot_);
-              franka::RobotState robot_state = franka_robot->getRobotState();
-              franka::GripperState gripper_state = franka_robot->getGripperState();
+        if (robot_access_mutex_.try_lock()) {
+          switch(robot_->robot_type_)
+          {
+            case RobotType::FRANKA: {
+                FrankaRobot* franka_robot = dynamic_cast<FrankaRobot* >(robot_);
+                franka::RobotState robot_state = franka_robot->getRobotState();
+                franka::GripperState gripper_state = franka_robot->getGripperState();
 
-              double duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-                  std::chrono::steady_clock::now() - start_time).count();
+                double duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - start_time).count();
 
-              robot_state_data_->log_pose_desired(robot_state.O_T_EE_d); // Fictitious call to log pose desired so pose_desired buffer length matches during non-skill execution
-              robot_state_data_->log_robot_state(robot_state, duration / 1000.0);
-              robot_state_data_->log_gripper_state(gripper_state);
-            }
-            break;
-          case RobotType::UR5E:
-            break;
+                robot_state_data_->log_pose_desired(robot_state.O_T_EE_d); // Fictitious call to log pose desired so pose_desired buffer length matches during non-skill execution
+                robot_state_data_->log_robot_state(robot_state, duration / 1000.0);
+                robot_state_data_->log_gripper_state(gripper_state);
+              }
+              break;
+            case RobotType::UR5E:
+              break;
+          }
+          robot_access_mutex_.unlock();
         }
       }
   });
@@ -600,22 +603,19 @@ void run_loop::run_on_franka() {
 
         // NOTE: We keep on running the last skill even if it is finished!!
         if (skill != nullptr && meta_skill != nullptr) {
+          robot_access_mutex_.lock();
           if (!meta_skill->isComposableSkill() && !skill->get_termination_handler()->done_) {
             // Execute skill.
             log_skill_info(skill);
-            running_skill_ = true;
             meta_skill->execute_skill_on_franka(this, dynamic_cast<FrankaRobot* >(robot_), robot_state_data_);
-            running_skill_ = false;
           } else if (meta_skill->isComposableSkill()) {
             log_skill_info(skill);
-            running_skill_ = true;
             meta_skill->execute_skill_on_franka(this, dynamic_cast<FrankaRobot* >(robot_), robot_state_data_);
-            running_skill_ = false;
           } else {
             finish_current_skill(skill);
-            running_skill_ = false;
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
           }
+          robot_access_mutex_.unlock();
         }
 
         // Complete old skills and acquire new skills
@@ -625,9 +625,9 @@ void run_loop::run_on_franka() {
         BaseSkill* new_skill = skill_manager_.get_current_skill();
         if (should_start_new_skill(skill, new_skill)) {
           std::cout << "Will start skill\n";
-          running_skill_ = true;
+          robot_access_mutex_.lock();
           start_new_skill(new_skill);
-          running_skill_ = false;
+          robot_access_mutex_.unlock();
         }
 
         // Sleep to maintain 1Khz frequency, not sure if this is required or not.
@@ -641,7 +641,6 @@ void run_loop::run_on_franka() {
     } catch (const franka::Exception& ex) {
       std::cout << "Caught Franka Exception\n";
       run_loop_ok_ = false;
-      running_skill_ = false;
 
       // Alert franka_action_lib that an exception has occurred      
       std::string error_description = ex.what();

--- a/src/catkin_ws/src/franka_action_lib/frankapy/franka_arm.py
+++ b/src/catkin_ws/src/franka_action_lib/frankapy/franka_arm.py
@@ -259,6 +259,8 @@ class FrankaArm:
         goal = skill.create_goal()
 
         self._send_goal(goal, cb=lambda x: skill.feedback_callback(x), retry=retry)
+        # this is so the gripper state can be updated, which happens with a small lag
+        sleep(FC.GRIPPER_CMD_SLEEP_TIME)
 
     def open_gripper(self):
         '''Opens gripper to maximum width

--- a/src/catkin_ws/src/franka_action_lib/frankapy/franka_constants.py
+++ b/src/catkin_ws/src/franka_action_lib/frankapy/franka_constants.py
@@ -4,6 +4,9 @@ import numpy as np
 from autolab_core import RigidTransform
 
 class FrankaConstants:
+    '''
+    All units are SI. 
+    '''
 
     LOGGING_LEVEL = logging.INFO
 
@@ -45,5 +48,7 @@ class FrankaConstants:
     ROS_ROBOLIB_STATUS_PUBLISHER_NAME = '/robolib_status_publisher_node/robolib_status'
     ROS_EXECUTE_SKILL_ACTION_SERVER_NAME = '/execute_skill_action_server_node/execute_skill'
 
-    DEFAULT_ROBOLIB_TIMEOUT = 5 # in seconds
+    DEFAULT_ROBOLIB_TIMEOUT = 5 
     ACTION_WAIT_LOOP_TIME = 0.001
+
+    GRIPPER_CMD_SLEEP_TIME = 0.2


### PR DESCRIPTION
…hread to intermittently save data, and most importantly gripper data. This allows gripper data to be updated as otherwise, once a skill executes, grippper state will never change b/c skills can only update robot state, not gripper state